### PR TITLE
Install vim on different OS

### DIFF
--- a/.rakudist/sparrowfile
+++ b/.rakudist/sparrowfile
@@ -1,0 +1,5 @@
+package-install %(
+  alpine => "vim",
+  debian => "vim",
+  centos => "vim-enhanced"
+);


### PR DESCRIPTION
Hi! This is RakuDist profile that allows to test the module+vim against different OS. You can find example reports here:

http://repo.westus.cloudapp.azure.com/rakudist/reports/melezhik/p6-Text-VimColour/

